### PR TITLE
:sparkles: improvements

### DIFF
--- a/external_resources_io/cli.py
+++ b/external_resources_io/cli.py
@@ -4,7 +4,7 @@ from typing import Annotated, Protocol, cast
 
 from pydantic import BaseModel
 
-from external_resources_io.config import Config, get_env_var_name
+from external_resources_io.config import Config, EnvVar
 from external_resources_io.input import (
     AppInterfaceProvision,
     parse_model,
@@ -84,7 +84,7 @@ def generate_variables_tf(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar=get_env_var_name("variables_tf_file"),
+            envvar=EnvVar.OUTPUTS_FILE,
         ),
     ] = Path(config.variables_tf_file),
 ) -> None:
@@ -110,7 +110,7 @@ def generate_backend_tf(
             show_default=False,
             readable=True,
             file_okay=True,
-            envvar=get_env_var_name("input_file"),
+            envvar=EnvVar.INPUT_FILE,
         ),
     ],
     output: Annotated[
@@ -119,7 +119,7 @@ def generate_backend_tf(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar=get_env_var_name("backend_tf_file"),
+            envvar=EnvVar.OUTPUTS_FILE,
         ),
     ] = Path(config.backend_tf_file),
 ) -> None:
@@ -144,7 +144,7 @@ def generate_tf_vars_json(
             show_default=False,
             readable=True,
             file_okay=True,
-            envvar=get_env_var_name("input_file"),
+            envvar=EnvVar.INPUT_FILE,
         ),
     ],
     output: Annotated[
@@ -153,7 +153,7 @@ def generate_tf_vars_json(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar=get_env_var_name("tf_vars_file"),
+            envvar=EnvVar.OUTPUTS_FILE,
         ),
     ] = Path(config.tf_vars_file),
 ) -> None:

--- a/external_resources_io/cli.py
+++ b/external_resources_io/cli.py
@@ -4,14 +4,13 @@ from typing import Annotated, Protocol, cast
 
 from pydantic import BaseModel
 
+from external_resources_io.config import Config, get_env_var_name
 from external_resources_io.input import (
     AppInterfaceProvision,
     parse_model,
     read_input_from_file,
 )
 from external_resources_io.terraform.generators import (
-    DEFAULT_BACKEND_TF_FILE,
-    DEFAULT_VARIABLES_TF_FILE,
     create_backend_tf_file,
     create_tf_vars_json,
     create_variables_tf_file,
@@ -28,6 +27,7 @@ except ImportError:
 app = typer.Typer()
 tf_app = typer.Typer()
 app.add_typer(tf_app, name="tf")
+config = Config()
 
 
 class AppInterfaceInputInterface(Protocol):
@@ -84,9 +84,9 @@ def generate_variables_tf(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar="VARIABLES_TF_FILE",
+            envvar=get_env_var_name("variables_tf_file"),
         ),
-    ] = Path(DEFAULT_VARIABLES_TF_FILE),
+    ] = Path(config.variables_tf_file),
 ) -> None:
     """Generates Terraform variables.tf file."""
     create_variables_tf_file(
@@ -110,7 +110,7 @@ def generate_backend_tf(
             show_default=False,
             readable=True,
             file_okay=True,
-            envvar="ER_INPUT_FILE",
+            envvar=get_env_var_name("input_file"),
         ),
     ],
     output: Annotated[
@@ -119,9 +119,9 @@ def generate_backend_tf(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar="BACKEND_TF_FILE",
+            envvar=get_env_var_name("backend_tf_file"),
         ),
-    ] = Path(DEFAULT_BACKEND_TF_FILE),
+    ] = Path(config.backend_tf_file),
 ) -> None:
     """Generates Terraform backends.tf file."""
     ai_input = _get_ai_input(app_interface_input_class, input_file)
@@ -144,7 +144,7 @@ def generate_tf_vars_json(
             show_default=False,
             readable=True,
             file_okay=True,
-            envvar="ER_INPUT_FILE",
+            envvar=get_env_var_name("input_file"),
         ),
     ],
     output: Annotated[
@@ -153,9 +153,9 @@ def generate_tf_vars_json(
             help="Output file",
             dir_okay=False,
             writable=True,
-            envvar="BACKEND_TF_FILE",
+            envvar=get_env_var_name("tf_vars_file"),
         ),
-    ] = Path(DEFAULT_BACKEND_TF_FILE),
+    ] = Path(config.tf_vars_file),
 ) -> None:
     """Generates Terraform tfvars.json file."""
     ai_input = _get_ai_input(app_interface_input_class, input_file)

--- a/external_resources_io/config.py
+++ b/external_resources_io/config.py
@@ -1,0 +1,31 @@
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+
+
+class Config(BaseSettings):
+    """Environment Variables."""
+
+    # general settings
+    action: str = "Apply"
+    dry_run: bool = True
+    log_level: str = "INFO"
+
+    # app-interface input related
+    input_file: str = "/inputs/input.json"
+
+    backend_tf_file: str = "module/backend.tf"
+    outputs_file: str = "tmp/outputs.json"
+    plan_file_json: str = "tmp/plan.json"
+    terraform_cmd: str = "terraform"
+    tf_vars_file: str = "module/tfvars.json"
+    variables_tf_file: str = "module/variables.tf"
+
+    @field_validator("action", mode="before")
+    @classmethod
+    def lower_action(cls, v: str) -> str:
+        """Transform the action to lowercase."""
+        return v.lower()
+
+
+def get_env_var_name(field_name: str) -> str:
+    return Config.model_fields[field_name].alias or field_name.upper()

--- a/external_resources_io/config.py
+++ b/external_resources_io/config.py
@@ -24,7 +24,7 @@ class Config(BaseSettings):
     outputs_file: str = "tmp/outputs.json"
     plan_file_json: str = "tmp/plan.json"
     terraform_cmd: str = "terraform"
-    tf_vars_file: str = "module/tfvars.json"
+    tf_vars_file: str = "module/terraform.tfvars.json"
     variables_tf_file: str = "module/variables.tf"
 
     @field_validator("action", mode="before")

--- a/external_resources_io/config.py
+++ b/external_resources_io/config.py
@@ -1,12 +1,19 @@
+from enum import StrEnum
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, EnvSettingsSource
+
+
+class Action(StrEnum):
+    APPLY = "apply"
+    DESTROY = "destroy"
 
 
 class Config(BaseSettings):
     """Environment Variables."""
 
     # general settings
-    action: str = "Apply"
+    action: Action = Action.APPLY
     dry_run: bool = True
     log_level: str = "INFO"
 
@@ -22,8 +29,8 @@ class Config(BaseSettings):
 
     @field_validator("action", mode="before")
     @classmethod
-    def lower_action(cls, v: str) -> str:
-        """Transform the action to lowercase."""
+    def action_lower(cls, v: str) -> str:
+        """Always lower action string to match with Action enum."""
         return v.lower()
 
 

--- a/external_resources_io/config.py
+++ b/external_resources_io/config.py
@@ -1,5 +1,5 @@
 from pydantic import field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, EnvSettingsSource
 
 
 class Config(BaseSettings):
@@ -27,5 +27,15 @@ class Config(BaseSettings):
         return v.lower()
 
 
+_env_settings = EnvSettingsSource(
+    Config,
+    case_sensitive=False,  # we want to user UPPERCASE env variable names only
+    env_prefix=Config.model_config["env_prefix"],
+    env_nested_delimiter=Config.model_config["env_nested_delimiter"],
+)
+
+
 def get_env_var_name(field_name: str) -> str:
-    return Config.model_fields[field_name].alias or field_name.upper()
+    return _env_settings._extract_field_info(  # noqa: SLF001
+        Config.model_fields[field_name], field_name
+    )[0][1].upper()  # we want to user UPPERCASE env variable names only

--- a/external_resources_io/input.py
+++ b/external_resources_io/input.py
@@ -7,6 +7,8 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
+from external_resources_io.config import Config
+
 
 class TerraformProvisionOptions(BaseModel):
     tf_state_bucket: str
@@ -34,9 +36,9 @@ def parse_model(model_class: type[T], data: Mapping[str, Any]) -> T:
 
 
 def read_input_from_file(file_path: Path | str | None = None) -> dict[str, Any]:
-    if not file_path:
-        file_path = os.environ.get("ER_INPUT_FILE", "/inputs/input.json")
-    return json.loads(Path(file_path).read_text(encoding="utf-8"))
+    return json.loads(
+        Path(file_path or Config().input_file).read_text(encoding="utf-8")
+    )
 
 
 def read_input_from_env_var(var: str = "INPUT") -> dict[str, Any]:

--- a/external_resources_io/log.py
+++ b/external_resources_io/log.py
@@ -1,0 +1,40 @@
+import logging
+import logging.config
+
+from external_resources_io.config import Config
+
+
+class DryRunFilter(logging.Filter):
+    """Adds a DRY_RUN prefix"""
+
+    def __init__(self, *, dry_run: bool) -> None:
+        super().__init__()
+        if dry_run:
+            self.prefix = "DRY_RUN - "
+        else:
+            self.prefix = ""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Filter method"""
+        record.prefix = self.prefix
+        return True
+
+
+def setup_logging() -> None:
+    """Returns a logger"""
+    config = Config()
+    logging.config.dictConfig({
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {"prefix_filter": {"()": DryRunFilter, "dry_run": config.dry_run}},
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "filters": ["prefix_filter"],
+                "formatter": "base",
+            }
+        },
+        "formatters": {"base": {"format": "%(prefix)s%(levelname)s - %(message)s"}},
+        "root": {"level": config.log_level, "handlers": ["console"]},
+        "botocore": {"level": "ERROR", "handlers": ["console"]},
+    })

--- a/external_resources_io/terraform/__init__.py
+++ b/external_resources_io/terraform/__init__.py
@@ -12,6 +12,7 @@ from .plan import (
     ResourceChange,
     TerraformJsonPlanParser,
 )
+from .run import terraform_run
 
 __all__ = [
     "Action",
@@ -24,4 +25,5 @@ __all__ = [
     "create_backend_tf_file",
     "create_tf_vars_json",
     "create_variables_tf_file",
+    "terraform_run",
 ]

--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -21,14 +21,15 @@ class SetEncoder(json.JSONEncoder):
 
 
 def create_tf_vars_json(
-    input_data: BaseModel, output_file: Path | str | None = None
+    input_data: BaseModel,
+    output_file: Path | str | None = None,
+    *,
+    exclude_none: bool = True,
 ) -> Path:
     """Helper method to create teraform vars files. Used in terraform based ERv2 modules."""
     output = Path(output_file or Config().tf_vars_file)
     output.write_text(
-        input_data.model_dump_json(
-            exclude_none=True,
-        ),
+        input_data.model_dump_json(exclude_none=exclude_none),
         encoding="utf-8",
     )
     return output

--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -1,6 +1,5 @@
 # ruff: noqa: ANN401
 import json
-import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 from types import UnionType
@@ -11,6 +10,7 @@ from pydantic_core import PydanticUndefined
 
 from external_resources_io.config import Config
 from external_resources_io.input import AppInterfaceProvision
+from external_resources_io.terraform.run import terraform_fmt
 
 
 class SetEncoder(json.JSONEncoder):
@@ -197,23 +197,3 @@ def _convert_json_to_hcl(data: dict) -> str:
         hcl_blocks.append("\n".join(block_lines))
 
     return "\n".join(hcl_blocks)
-
-
-def terraform_available() -> bool:
-    try:
-        subprocess.run(["terraform", "--version"], check=True, capture_output=True)
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-
-
-def terraform_fmt(data: str) -> str:
-    if not terraform_available():
-        return data
-    return subprocess.run(
-        ["terraform", "fmt", "-"],
-        input=data,
-        text=True,
-        check=True,
-        capture_output=True,
-    ).stdout

--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -1,6 +1,5 @@
 # ruff: noqa: ANN401
 import json
-import os
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
@@ -10,15 +9,8 @@ from typing import Any, Literal, Union, get_args, get_origin
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
+from external_resources_io.config import Config
 from external_resources_io.input import AppInterfaceProvision
-
-TF_VARS_FILE_ENV_VAR = "TF_VARS_FILE"
-BACKEND_TF_FILE_ENV_VAR = "BACKEND_TF_FILE"
-VARIABLES_TF_FILE_ENV_VAR = "VARIABLES_TF_FILE"
-
-DEFAULT_TF_VARS_FILE = "./module/tfvars.json"
-DEFAULT_BACKEND_TF_FILE = "./module/backend.tf"
-DEFAULT_VARIABLES_TF_FILE = "./module/variables.tf"
 
 
 class SetEncoder(json.JSONEncoder):
@@ -32,9 +24,7 @@ def create_tf_vars_json(
     input_data: BaseModel, output_file: Path | str | None = None
 ) -> Path:
     """Helper method to create teraform vars files. Used in terraform based ERv2 modules."""
-    if not output_file:
-        output_file = os.environ.get(TF_VARS_FILE_ENV_VAR, DEFAULT_TF_VARS_FILE)
-    output = Path(output_file)
+    output = Path(output_file or Config().tf_vars_file)
     output.write_text(
         input_data.model_dump_json(
             exclude_none=True,
@@ -48,9 +38,7 @@ def create_backend_tf_file(
     provision_data: AppInterfaceProvision, output_file: Path | str | None = None
 ) -> Path:
     """Helper method to create teraform backend configuration. Used in terraform based ERv2 modules."""
-    if not output_file:
-        output_file = os.environ.get(BACKEND_TF_FILE_ENV_VAR, DEFAULT_BACKEND_TF_FILE)
-    output = Path(output_file)
+    output = Path(output_file or Config().backend_tf_file)
     output.write_text(
         terraform_fmt(f"""\
             terraform {{
@@ -71,11 +59,7 @@ def create_variables_tf_file(
     model: type[BaseModel], variables_file: Path | str | None = None
 ) -> Path:
     """Generates Terraform variables.tf file."""
-    if not variables_file:
-        variables_file = os.environ.get(
-            VARIABLES_TF_FILE_ENV_VAR, DEFAULT_VARIABLES_TF_FILE
-        )
-    output = Path(variables_file)
+    output = Path(variables_file or Config().variables_tf_file)
     output.write_text(
         terraform_fmt(
             _convert_json_to_hcl(_generate_terraform_variables_from_model(model))

--- a/external_resources_io/terraform/run.py
+++ b/external_resources_io/terraform/run.py
@@ -1,0 +1,45 @@
+import logging
+import subprocess
+from collections.abc import Sequence
+
+from external_resources_io.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def terraform_available() -> bool:
+    try:
+        subprocess.run(["terraform", "--version"], check=True, capture_output=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def terraform_fmt(data: str) -> str:
+    if not terraform_available():
+        return data
+    return subprocess.run(
+        ["terraform", "fmt", "-"],
+        input=data,
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+def terraform_run(args: Sequence[str], *, dry_run: bool | None = None) -> str:
+    """Run a terraform command."""
+    config = Config()
+    args = [*config.terraform_cmd.split(), *args]
+    dry_run = dry_run if dry_run is not None else config.dry_run
+    if dry_run:
+        logger.debug(f"cmd: {' '.join(args)}")
+        return ""
+
+    try:
+        cmd = subprocess.run(args, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        logger.exception(e.stdout)
+        logger.exception(e.stderr)
+        raise
+    return cmd.stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ known-first-party = ["external_resources_io"]
 
 # Mypy configuration
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 files = ["external_resources_io", "tests"]
 enable_error_code = ["truthy-bool", "redundant-expr"]
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "external-resources-io"
-version = "0.5.1"
+version = "0.6.0"
 requires-python = ">=3.11"
 description = "Util classes for AppSRE External Resources system"
 license = { text = "Apache 2.0" }
 readme = "README.md"
 authors = [{ name = "Jordi Piriz", email = "jpiriz@redhat.com" }]
-dependencies = ["pydantic >=2.10.0"]
+dependencies = ["pydantic >=2.10.0", "pydantic-settings>=2.7.1"]
 
 [project.scripts]
 external-resources-io = 'external_resources_io.cli:app'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,4 @@ branch = true
 omit = ["*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 87

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+import pytest
+
+from external_resources_io.config import Config
+
+
+def test_config_defaults() -> None:
+    config = Config()
+    assert config.action == "apply"
+    assert config.dry_run
+    assert config.log_level == "INFO"
+
+
+def test_config_readenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACTION", "fake")
+    monkeypatch.setenv("DRY_RUN", "0")
+    config = Config()
+    assert config.action == "fake"
+    assert not config.dry_run
+
+
+def test_config_lower_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACTION", "DESTROY")
+    config = Config()
+    assert config.action == "destroy"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,24 +1,31 @@
 import pytest
+from pydantic import ValidationError
 
-from external_resources_io.config import Config
+from external_resources_io.config import Action, Config
 
 
 def test_config_defaults() -> None:
     config = Config()
-    assert config.action == "apply"
+    assert config.action == Action.APPLY
     assert config.dry_run
     assert config.log_level == "INFO"
 
 
 def test_config_readenv(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ACTION", "fake")
+    monkeypatch.setenv("PLAN_FILE_JSON", "fake")
     monkeypatch.setenv("DRY_RUN", "0")
     config = Config()
-    assert config.action == "fake"
+    assert config.plan_file_json == "fake"
     assert not config.dry_run
 
 
-def test_config_lower_action(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_action(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ACTION", "DESTROY")
     config = Config()
-    assert config.action == "destroy"
+    assert config.action == Action.DESTROY
+
+
+def test_config_bad_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACTION", "fake")
+    with pytest.raises(ValidationError):
+        Config()

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -22,7 +22,7 @@ def test_read_input_from_file_env_var(
 ) -> None:
     input_json = tmp_path / "input.json"
     input_json.write_text(json.dumps(ai_data))
-    monkeypatch.setenv("ER_INPUT_FILE", str(input_json.absolute()))
+    monkeypatch.setenv("INPUT_FILE", str(input_json.absolute()))
 
     input_data = read_input_from_file()
     assert input_data == ai_data

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -11,6 +11,7 @@ from external_resources_io.terraform.generators import (
     create_tf_vars_json,
     terraform_fmt,
 )
+from external_resources_io.terraform.run import terraform_run
 
 
 @pytest.fixture
@@ -60,3 +61,16 @@ def test_create_backend_tf_file_output_env_var(
     monkeypatch.setenv(get_env_var_name("backend_tf_file"), str(temp_file))
     create_backend_tf_file(provision_data)
     assert temp_file.exists()
+
+
+def test_terraform_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERRAFORM_CMD", "echo")
+    monkeypatch.setenv("DRY_RUN", "0")
+    assert terraform_run(["foo bar"]) == "foo bar\n"
+    assert terraform_run(["version"], dry_run=True) == ""  # noqa: PLC1901
+
+
+def test_terraform_run_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERRAFORM_CMD", "ls")
+    with pytest.raises(subprocess.CalledProcessError):
+        terraform_run(["what ever - will throw an error"], dry_run=False)

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel
 
+from external_resources_io.config import get_env_var_name
 from external_resources_io.input import AppInterfaceProvision
 from external_resources_io.terraform.generators import (
-    BACKEND_TF_FILE_ENV_VAR,
-    TF_VARS_FILE_ENV_VAR,
     create_backend_tf_file,
     create_tf_vars_json,
     terraform_fmt,
@@ -29,7 +28,7 @@ def test_tf_vars_json(data: BaseModel, temp_file: Path) -> None:
 def test_tf_vars_json_output_env_var(
     data: BaseModel, temp_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv(TF_VARS_FILE_ENV_VAR, str(temp_file))
+    monkeypatch.setenv(get_env_var_name("tf_vars_file"), str(temp_file))
     create_tf_vars_json(data)
     assert temp_file.exists()
 
@@ -58,6 +57,6 @@ def test_create_backend_tf_file_output_env_var(
     temp_file: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(BACKEND_TF_FILE_ENV_VAR, str(temp_file))
+    monkeypatch.setenv(get_env_var_name("backend_tf_file"), str(temp_file))
     create_backend_tf_file(provision_data)
     assert temp_file.exists()

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel
 
-from external_resources_io.config import get_env_var_name
+from external_resources_io.config import EnvVar
 from external_resources_io.input import AppInterfaceProvision
 from external_resources_io.terraform.generators import (
     create_backend_tf_file,
@@ -29,7 +29,7 @@ def test_tf_vars_json(data: BaseModel, temp_file: Path) -> None:
 def test_tf_vars_json_output_env_var(
     data: BaseModel, temp_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv(get_env_var_name("tf_vars_file"), str(temp_file))
+    monkeypatch.setenv(EnvVar.TF_VARS_FILE, str(temp_file))
     create_tf_vars_json(data)
     assert temp_file.exists()
 
@@ -58,7 +58,7 @@ def test_create_backend_tf_file_output_env_var(
     temp_file: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(get_env_var_name("backend_tf_file"), str(temp_file))
+    monkeypatch.setenv(EnvVar.BACKEND_TF_FILE, str(temp_file))
     create_backend_tf_file(provision_data)
     assert temp_file.exists()
 

--- a/tests/test_terraform_variables.py
+++ b/tests/test_terraform_variables.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
-from external_resources_io.config import get_env_var_name
+from external_resources_io.config import EnvVar
 from external_resources_io.terraform.generators import (
     _convert_json_to_hcl,
     _generate_terraform_variable,
@@ -285,6 +285,6 @@ def test_create_variables_tf_file_output_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     tf_file = tmp_path / "variables.tf"
-    monkeypatch.setenv(get_env_var_name("variables_tf_file"), str(tf_file))
+    monkeypatch.setenv(EnvVar.VARIABLES_TF_FILE, str(tf_file))
     create_variables_tf_file(sample_model)
     assert tf_file.exists()

--- a/tests/test_terraform_variables.py
+++ b/tests/test_terraform_variables.py
@@ -16,6 +16,8 @@ from external_resources_io.terraform.generators import (
     _generate_terraform_variables_from_model,
     _get_terraform_type,
     create_variables_tf_file,
+)
+from external_resources_io.terraform.run import (
     terraform_available,
     terraform_fmt,
 )

--- a/tests/test_terraform_variables.py
+++ b/tests/test_terraform_variables.py
@@ -9,8 +9,8 @@ import pytest
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
 
+from external_resources_io.config import get_env_var_name
 from external_resources_io.terraform.generators import (
-    VARIABLES_TF_FILE_ENV_VAR,
     _convert_json_to_hcl,
     _generate_terraform_variable,
     _generate_terraform_variables_from_model,
@@ -283,6 +283,6 @@ def test_create_variables_tf_file_output_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     tf_file = tmp_path / "variables.tf"
-    monkeypatch.setenv(VARIABLES_TF_FILE_ENV_VAR, str(tf_file))
+    monkeypatch.setenv(get_env_var_name("variables_tf_file"), str(tf_file))
     create_variables_tf_file(sample_model)
     assert tf_file.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -87,10 +88,11 @@ toml = [
 
 [[package]]
 name = "external-resources-io"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.optional-dependencies]
@@ -109,8 +111,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.1" },
 ]
+provides-extras = ["cli"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -276,6 +280,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/7b/c58a586cd7d9ac66d2ee4ba60ca2d241fa837c02bca9bea80a9a8c3d22a9/pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93", size = 79920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/46/93416fdae86d40879714f72956ac14df9c7b76f7d41a4d68aa9f71a0028b/pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd", size = 29718 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -310,6 +327,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]
 
 [[package]]


### PR DESCRIPTION

`external-resource-io.config`
---

Introduce a standard environment parsing module, `external-resource-io.config`.

Usage:

```python
from external_resources_io.config import Config

Config().dry_run
```

`external-resource-io.log`
---

Default method to setup the Python logging.

Usage:

```
from external_resources_io.log import setup_logging

setup_logging()
```

`external-resource-io.run`
---

Add a `terraform_run` wrapper.

Usage:

```python
from external_resources_io.terraform import terraform_run

terraform_run(["state", "list"]
```

**Breaking changes**
---
Rename `ER_INPUT_FILE` to `INPUT_FILE`