### PR TITLE
:sparkles: support terraform vars descriptions

### DIFF
--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -73,7 +73,9 @@ def create_variables_tf_file(
 def _generate_fields(model: type[BaseModel]) -> dict[str, dict]:
     return {
         field_name: _generate_terraform_variable(
-            python_type=field_info.annotation, default=field_info.default
+            python_type=field_info.annotation,
+            default=field_info.default,
+            description=field_info.description,
         )
         for field_name, field_info in model.model_fields.items()
     }
@@ -84,7 +86,9 @@ def _generate_terraform_variables_from_model(model: type[BaseModel]) -> dict:
     return {"variable": _generate_fields(model)}
 
 
-def _generate_terraform_variable(python_type: Any, default: Any = None) -> dict:
+def _generate_terraform_variable(
+    python_type: Any, default: Any = None, description: str | None = None
+) -> dict:
     """Generates a Terraform variable block."""
     variable_block: dict[str, str | None] = {"type": _get_terraform_type(python_type)}
 
@@ -94,6 +98,8 @@ def _generate_terraform_variable(python_type: Any, default: Any = None) -> dict:
             if default and isinstance(default, BaseModel)
             else default
         )
+    if description:
+        variable_block["description"] = description
     return variable_block
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external-resources-io"
-version = "0.6.1"
+version = "0.6.2"
 requires-python = ">=3.11"
 description = "Util classes for AppSRE External Resources system"
 license = { text = "Apache 2.0" }
@@ -23,6 +23,7 @@ dev = [
     "pytest ~=8.3",
     "pytest-cov ~=6.0",
     "ruff ~=0.8",
+    "typer>=0.15.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ toml = [
 
 [[package]]
 name = "external-resources-io"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -132,6 +132,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "typer" },
 ]
 
 [package.metadata]
@@ -148,6 +149,7 @@ dev = [
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-cov", specifier = "~=6.0" },
     { name = "ruff", specifier = "~=0.8" },
+    { name = "typer", specifier = ">=0.15.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support the Terraform variable `description` field.