### PR TITLE
fix(terraform): map Literal[int] to "number" in variable generation

### DIFF
--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -116,6 +116,10 @@ def _convert_generic_types(origin: Any, args: Any) -> str:  # noqa: PLR0911
             return f"map({_get_terraform_type(args[1])})" if args else "map(any)"
 
         case t if t is Literal:
+            if args and all(isinstance(a, bool) for a in args):
+                return "bool"
+            if args and all(isinstance(a, int) for a in args):
+                return "number"
             return "string"
 
         case t if t in {UnionType, Union}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external-resources-io"
-version = "0.6.2"
+version = "0.6.3"
 requires-python = ">=3.11"
 description = "Util classes for AppSRE External Resources system"
 license = { text = "Apache 2.0" }

--- a/tests/test_terraform_variables.py
+++ b/tests/test_terraform_variables.py
@@ -238,6 +238,7 @@ def sample_model() -> type[BaseModel]:
         (dict[str, int], "map(number)"),
         (dict, "map(any)"),
         (Literal["on", "off"], "string"),
+        (Literal[1, 2, 3], "number"),
         (NestedModel, "object({field = string,numeric = number})"),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ toml = [
 
 [[package]]
 name = "external-resources-io"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Literal[...] types were unconditionally mapped to "string". Now inspects the Literal args to determine the correct Terraform type: all bool → "bool", all int → "number", otherwise → "string".