### PR TITLE
Replace DynamoDB locking with S3 use_lockfile

### DIFF
--- a/external_resources_io/input.py
+++ b/external_resources_io/input.py
@@ -13,7 +13,6 @@ from external_resources_io.config import Config
 class TerraformProvisionOptions(BaseModel):
     tf_state_bucket: str
     tf_state_region: str
-    tf_state_dynamodb_table: str
     tf_state_key: str
 
 

--- a/external_resources_io/terraform/generators.py
+++ b/external_resources_io/terraform/generators.py
@@ -44,11 +44,11 @@ def create_backend_tf_file(
         terraform_fmt(f"""\
             terraform {{
               backend "s3" {{
-                bucket = "{provision_data.module_provision_data.tf_state_bucket}"
-                key    = "{provision_data.module_provision_data.tf_state_key}"
-                region = "{provision_data.module_provision_data.tf_state_region}"
-                dynamodb_table = "{provision_data.module_provision_data.tf_state_dynamodb_table}"
-                profile = "external-resources-state"
+                bucket       = "{provision_data.module_provision_data.tf_state_bucket}"
+                key          = "{provision_data.module_provision_data.tf_state_key}"
+                region       = "{provision_data.module_provision_data.tf_state_region}"
+                use_lockfile = true
+                profile      = "external-resources-state"
               }}
             }}"""),
         encoding="utf-8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external-resources-io"
-version = "0.6.3"
+version = "0.6.4"
 requires-python = ">=3.11"
 description = "Util classes for AppSRE External Resources system"
 license = { text = "Apache 2.0" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def ai_data() -> dict[str, Any]:
             "module_provision_data": {
                 "tf_state_bucket": "test-external-resources-state",
                 "tf_state_region": "us-east-1",
-                "tf_state_dynamodb_table": "test-external-resources-lock",
                 "tf_state_key": "aws/ter-int-dev/aws-iam-role/test-external-resources-iam-role/terraform.state",
             },
         },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,6 @@ def input_file(tmp_path: Path) -> Path:
                 "module_provision_data": {
                     "tf_state_bucket": "dev",
                     "tf_state_region": "us-east-1",
-                    "tf_state_dynamodb_table": "terraform-lock",
                     "tf_state_key": "terraform.tfstate",
                 },
             },

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -41,11 +41,11 @@ def test_create_backend_tf_file(
     expected_text = """\
 terraform {
   backend "s3" {
-    bucket         = "test-external-resources-state"
-    key            = "aws/ter-int-dev/aws-iam-role/test-external-resources-iam-role/terraform.state"
-    region         = "us-east-1"
-    dynamodb_table = "test-external-resources-lock"
-    profile        = "external-resources-state"
+    bucket       = "test-external-resources-state"
+    key          = "aws/ter-int-dev/aws-iam-role/test-external-resources-iam-role/terraform.state"
+    region       = "us-east-1"
+    use_lockfile = true
+    profile      = "external-resources-state"
   }
 }
 """

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ toml = [
 
 [[package]]
 name = "external-resources-io"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Remove deprecated DynamoDB-based state locking (`dynamodb_table`) from the S3 backend configuration
- Switch to native S3 lockfile-based locking via `use_lockfile = true` (Terraform 1.13.x)
- Remove `tf_state_dynamodb_table` field from `TerraformProvisionOptions` model

## Test plan
- [x] All existing tests updated and passing
- [x] `terraform validate` passes on generated backend config
- [x] mypy, ruff check, ruff format all clean

## Ticket

[APPSRE-13360](https://redhat.atlassian.net/browse/APPSRE-13360)